### PR TITLE
Fixed language name in bottom display

### DIFF
--- a/client/locales/de/main.ftl
+++ b/client/locales/de/main.ftl
@@ -1,5 +1,4 @@
 language-name = Deutsch
-language-name-en-us = German
 
 game-name = The Onion Oder Nicht The Onion
 

--- a/client/locales/en-US/main.ftl
+++ b/client/locales/en-US/main.ftl
@@ -1,5 +1,4 @@
 language-name = English (US)
-language-name-en-us = English (US)
 
 game-name = The Onion Or Not The Onion
 

--- a/client/src/components/footer.rs
+++ b/client/src/components/footer.rs
@@ -51,8 +51,6 @@ impl Component for FooterComponent {
                 html! {
                     <button type="button" disabled={is_selected} {onclick}>
                         {locale("language-name", language_identifier)}
-                        {" / "}
-                        {locale("language-name-en-us", language_identifier)}
                     </button>
                 }
             })


### PR DESCRIPTION
Fixes the language name displayed in the Footer:

![lang](https://user-images.githubusercontent.com/4084001/220967387-4dc934eb-d81e-4294-9fd7-93d84e3cfeab.png)
